### PR TITLE
[cache] Drop mq policy tests while making them optional via config

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -7,3 +7,8 @@ disable_by_id_check = true
 # shares space with the cache metadata on the 'metadata_dev' device.
 #
 # cache_dev = '/dev/vdc'
+
+# Optional cache policy name to override the default in dm-cache tests.
+# If specified, all test devices use this policy instead of the default smq policy.
+#
+# cache_policy = 'mq'

--- a/src/dmtest/cache/resize_origin_tests.py
+++ b/src/dmtest/cache/resize_origin_tests.py
@@ -76,11 +76,12 @@ def check_sized_metadata(cmeta, old_cache_dump, new_origin_size):
     check_mappings_truncation(cmeta, old_cache_dump, new_nr_origin_blocks)
 
 
-def expand_origin_with_reload(fix, policy_name):
+def t_expand_origin_with_reload(fix):
     cfg = fix.cfg
     fast_dev = cfg["metadata_dev"]
     origin_dev = cfg["data_dev"]
     cache_dev = cfg.get("cache_dev", None)
+    policy_name = cfg.get("cache_policy", "smq")
 
     block_size = units.kilo(32)
     cache_size = units.meg(128)
@@ -118,11 +119,12 @@ def expand_origin_with_reload(fix, policy_name):
         check_sized_metadata(cmeta, cdump.path, new_origin_size)
 
 
-def shrink_origin_with_reload_drops_mappings(fix, policy_name):
+def t_shrink_origin_with_reload_drops_mappings(fix):
     cfg = fix.cfg
     fast_dev = cfg["metadata_dev"]
     origin_dev = cfg["data_dev"]
     cache_dev = cfg.get("cache_dev", None)
+    policy_name = cfg.get("cache_policy", "smq")
 
     block_size = units.kilo(32)
     cache_size = units.meg(128)
@@ -163,11 +165,12 @@ def shrink_origin_with_reload_drops_mappings(fix, policy_name):
 # Actually there's no differences between teardown and reload while shrinking
 # the origin, as we always have to load a new dm-cache table to change the
 # target length. Here we test both the approaches to ensure test coverage.
-def shrink_origin_with_teardown_drops_mappings(fix, policy_name):
+def t_shrink_origin_with_teardown_drops_mappings(fix):
     cfg = fix.cfg
     fast_dev = cfg["metadata_dev"]
     origin_dev = cfg["data_dev"]
     cache_dev = cfg.get("cache_dev", None)
+    policy_name = cfg.get("cache_policy", "smq")
 
     block_size = units.kilo(32)
     cache_size = units.meg(128)
@@ -206,11 +209,12 @@ def shrink_origin_with_teardown_drops_mappings(fix, policy_name):
         check_sized_metadata(cmeta, cdump.path, new_origin_size)
 
 
-def shrink_origin_with_reload_should_fail_if_blocks_dirty(fix, policy_name):
+def t_shrink_origin_with_reload_should_fail_if_blocks_dirty(fix):
     cfg = fix.cfg
     fast_dev = cfg["metadata_dev"]
     origin_dev = cfg["data_dev"]
     cache_dev = cfg.get("cache_dev", None)
+    policy_name = cfg.get("cache_policy", "smq")
 
     block_size = units.kilo(32)
     cache_size = units.meg(128)
@@ -250,11 +254,12 @@ def shrink_origin_with_reload_should_fail_if_blocks_dirty(fix, policy_name):
             raise Exception("shrink cache origin succeeded without error")
 
 
-def shrink_origin_with_teardown_should_fail_if_blocks_dirty(fix, policy_name):
+def t_shrink_origin_with_teardown_should_fail_if_blocks_dirty(fix):
     cfg = fix.cfg
     fast_dev = cfg["metadata_dev"]
     origin_dev = cfg["data_dev"]
     cache_dev = cfg.get("cache_dev", None)
+    policy_name = cfg.get("cache_policy", "smq")
 
     block_size = units.kilo(32)
     cache_size = units.meg(128)
@@ -294,62 +299,21 @@ def shrink_origin_with_teardown_should_fail_if_blocks_dirty(fix, policy_name):
     else:
         raise Exception("shrink cache origin succeeded without error")
 
-
-def t_expand_origin_with_reload_mq(fix):
-    expand_origin_with_reload(fix, "mq")
-
-def t_expand_origin_with_reload_smq(fix):
-    expand_origin_with_reload(fix, "smq")
-
-def t_shrink_origin_with_reload_drops_mappings_mq(fix):
-    shrink_origin_with_reload_drops_mappings(fix, "mq")
-
-def t_shrink_origin_with_reload_drops_mappings_smq(fix):
-    shrink_origin_with_reload_drops_mappings(fix, "smq")
-
-def t_shrink_origin_with_teardown_drops_mappings_mq(fix):
-    shrink_origin_with_teardown_drops_mappings(fix, "mq")
-
-def t_shrink_origin_with_teardown_drops_mappings_smq(fix):
-    shrink_origin_with_teardown_drops_mappings(fix, "smq")
-
-def t_shrink_origin_with_reload_should_fail_if_blocks_dirty_mq(fix):
-    shrink_origin_with_reload_should_fail_if_blocks_dirty(fix, "mq")
-
-def t_shrink_origin_with_reload_should_fail_if_blocks_dirty_smq(fix):
-    shrink_origin_with_reload_should_fail_if_blocks_dirty(fix, "smq")
-
-def t_shrink_origin_with_teardown_should_fail_if_blocks_dirty_mq(fix):
-    shrink_origin_with_teardown_should_fail_if_blocks_dirty(fix, "mq")
-
-def t_shrink_origin_with_teardown_should_fail_if_blocks_dirty_smq(fix):
-    shrink_origin_with_teardown_should_fail_if_blocks_dirty(fix, "smq")
-
 #----------------------------------------------------------------
 
 def register(tests):
     tests.register_batch(
         "/cache/resize/",
         [
-            ("expand_origin_with_reload_mq",
-             t_expand_origin_with_reload_mq),
-            ("expand_origin_with_reload_smq",
-             t_expand_origin_with_reload_smq),
-            ("shrink_origin_with_reload_drops_mappings_mq",
-             t_shrink_origin_with_reload_drops_mappings_mq),
-            ("shrink_origin_with_reload_drops_mappings_smq",
-             t_shrink_origin_with_reload_drops_mappings_smq),
-            ("shrink_origin_with_teardown_drops_mappings_mq",
-             t_shrink_origin_with_teardown_drops_mappings_mq),
-            ("shrink_origin_with_teardown_drops_mappings_smq",
-             t_shrink_origin_with_teardown_drops_mappings_smq),
-            ("shrink_origin_with_reload_should_fail_if_blocks_dirty_mq",
-             t_shrink_origin_with_reload_should_fail_if_blocks_dirty_mq),
-            ("shrink_origin_with_reload_should_fail_if_blocks_dirty_smq",
-             t_shrink_origin_with_reload_should_fail_if_blocks_dirty_smq),
-            ("shrink_origin_with_teardown_should_fail_if_blocks_dirty_mq",
-             t_shrink_origin_with_teardown_should_fail_if_blocks_dirty_mq),
-            ("shrink_origin_with_teardown_should_fail_if_blocks_dirty_smq",
-             t_shrink_origin_with_teardown_should_fail_if_blocks_dirty_smq),
+            ("expand_origin_with_reload",
+             t_expand_origin_with_reload),
+            ("shrink_origin_with_reload_drops_mappings",
+             t_shrink_origin_with_reload_drops_mappings),
+            ("shrink_origin_with_teardown_drops_mappings",
+             t_shrink_origin_with_teardown_drops_mappings),
+            ("shrink_origin_with_reload_should_fail_if_blocks_dirty",
+             t_shrink_origin_with_reload_should_fail_if_blocks_dirty),
+            ("shrink_origin_with_teardown_should_fail_if_blocks_dirty",
+             t_shrink_origin_with_teardown_should_fail_if_blocks_dirty),
         ],
     )

--- a/src/dmtest/cache/small_config_tests.py
+++ b/src/dmtest/cache/small_config_tests.py
@@ -5,11 +5,12 @@ from dmtest.cache_stack import ManagedCacheStack, CachePolicy
 
 #----------------------------------------------------------------
 
-def small_config(fix, policy):
+def t_small_config(fix):
     cfg = fix.cfg
     fast_dev = cfg["metadata_dev"]
     origin_dev = cfg["data_dev"]
     cache_dev = cfg.get("cache_dev", None)
+    policy_name = cfg.get("cache_policy", "smq")
 
     stack = ManagedCacheStack(
         fast_dev,
@@ -20,16 +21,10 @@ def small_config(fix, policy):
         block_size = units.kilo(32),
         cache_size = units.kilo(50),
         target_len = units.kilo(50),
-        policy = policy,
+        policy = CachePolicy(policy_name),
     )
     with stack.activate():
         pass
-
-def t_small_config_mq(fix):
-    small_config(fix, CachePolicy("mq"))
-
-def t_small_config_smq(fix):
-    small_config(fix, CachePolicy("smq"))
 
 #----------------------------------------------------------------
 
@@ -37,7 +32,6 @@ def register(tests):
     tests.register_batch(
         "/cache/creation/",
         [
-            ("small_config_mq", t_small_config_mq),
-            ("small_config_smq", t_small_config_smq),
+            ("small_config", t_small_config),
         ],
     )

--- a/test_dependencies.toml
+++ b/test_dependencies.toml
@@ -314,50 +314,26 @@ targets = [ "vdo",]
 executables = [ "blockdev", "dd", "dmsetup", "vdoformat",]
 targets = [ "vdo",]
 
-["/cache/creation/small_config_mq"]
+["/cache/creation/small_config"]
 executables = [ "blockdev", "cache_check", "dd", "dmsetup",]
 targets = [ "cache", "linear",]
 
-["/cache/creation/small_config_smq"]
-executables = [ "blockdev", "cache_check", "dd", "dmsetup",]
-targets = [ "cache", "linear",]
-
-["/cache/resize/expand_origin_with_reload_mq"]
+["/cache/resize/expand_origin_with_reload"]
 executables = [ "blockdev", "cache_check", "cache_dump", "cache_restore", "dmsetup",]
 targets = [ "cache", "linear",]
 
-["/cache/resize/expand_origin_with_reload_smq"]
+["/cache/resize/shrink_origin_with_reload_drops_mappings"]
 executables = [ "blockdev", "cache_check", "cache_dump", "cache_restore", "dmsetup",]
 targets = [ "cache", "linear",]
 
-["/cache/resize/shrink_origin_with_reload_drops_mappings_mq"]
+["/cache/resize/shrink_origin_with_teardown_drops_mappings"]
 executables = [ "blockdev", "cache_check", "cache_dump", "cache_restore", "dmsetup",]
 targets = [ "cache", "linear",]
 
-["/cache/resize/shrink_origin_with_reload_drops_mappings_smq"]
-executables = [ "blockdev", "cache_check", "cache_dump", "cache_restore", "dmsetup",]
-targets = [ "cache", "linear",]
-
-["/cache/resize/shrink_origin_with_teardown_drops_mappings_mq"]
-executables = [ "blockdev", "cache_check", "cache_dump", "cache_restore", "dmsetup",]
-targets = [ "cache", "linear",]
-
-["/cache/resize/shrink_origin_with_teardown_drops_mappings_smq"]
-executables = [ "blockdev", "cache_check", "cache_dump", "cache_restore", "dmsetup",]
-targets = [ "cache", "linear",]
-
-["/cache/resize/shrink_origin_with_reload_should_fail_if_blocks_dirty_mq"]
+["/cache/resize/shrink_origin_with_reload_should_fail_if_blocks_dirty"]
 executables = [ "blockdev", "cache_check", "cache_restore", "dmsetup",]
 targets = [ "cache", "linear",]
 
-["/cache/resize/shrink_origin_with_reload_should_fail_if_blocks_dirty_smq"]
-executables = [ "blockdev", "cache_check", "cache_restore", "dmsetup",]
-targets = [ "cache", "linear",]
-
-["/cache/resize/shrink_origin_with_teardown_should_fail_if_blocks_dirty_mq"]
-executables = [ "blockdev", "cache_check", "cache_restore", "dmsetup",]
-targets = [ "cache", "linear",]
-
-["/cache/resize/shrink_origin_with_teardown_should_fail_if_blocks_dirty_smq"]
+["/cache/resize/shrink_origin_with_teardown_should_fail_if_blocks_dirty"]
 executables = [ "blockdev", "cache_check", "cache_restore", "dmsetup",]
 targets = [ "cache", "linear",]


### PR DESCRIPTION
Drop tests for the legacy mq policy, while introduce a new config option cache_policy to test it optionally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the example configuration file to document a new optional cache policy parameter for tests.
  - Simplified and consolidated cache test cases by removing duplicated policy-specific variants and streamlining test registration.
  - Reduced and clarified test entries in the test dependencies configuration to eliminate redundant variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->